### PR TITLE
lj2dayone UTF-8 bug workaround

### DIFF
--- a/getljxml.rb
+++ b/getljxml.rb
@@ -4,7 +4,7 @@
 
 lj_username = 'USERNAME' # replace USERNAME with your actual username
 lj_password = 'PASSWORD' # replace PASSWORD with your actual password
-firstyear = 2002 # Change this to the year your LJ starts
+firstyear = 2013 # Change this to the year your LJ starts
 
 # You shouldn't have to change these, but here they are just in case!
 lj_login_url = 'https://www.livejournal.com/login.bml' # LJ Login url
@@ -22,7 +22,7 @@ puts %x(curl --cookie-jar cookies.txt --data #{loginstring.dump} #{lj_login_url.
 		(1..12).each do |current_month|
 			poststring = 'what=journal&year=' + current_year.to_s + '&month=' + current_month.to_s + '&format=xml&header=on&encid=2&field_eventtime=on&field_subject=on&field_event=on'
 			open(current_year.to_s + '-' + current_month.to_s + '.xml', 'w') do |f| # Open a file named e.g. "2006-4.xml"
-				f.puts %x(curl --cookie cookies.txt --data #{poststring.dump}  #{lj_archive_url.dump}) # run CURL with the current month's POST info and dump the result into a file
+				f.puts %x(curl --cookie cookies.txt --data #{poststring.dump}  #{lj_archive_url.dump}).encode("UTF-8") # run CURL with the current month's POST info and dump the result into a file
 				end
 				puts "Waiting for 1 second so Livejournal doesn't have a fit..."
 				sleep(1)

--- a/lj2dayone.rb
+++ b/lj2dayone.rb
@@ -18,11 +18,14 @@ def create_dayone_entry(subject, date, text)
 		dayone_cmd_options = ''
 	end
 # If there's no subject, don't try to use it
-	if subject.empty?
-		return %x(echo <<'EOF' #{text.dump} | dayone #{dayone_cmd_options} --date="#{date} EST" new )
-	else
-		return %x(echo <<'EOF' #{subject.dump} #{text.dump} | #{dayone_cmd_options} dayone --date="#{date} EST" new )
-	end
+	#UGH Open scratch file
+	f = File.new("/tmp/" + `uuidgen`.strip + ".txt", "w+")
+	f.puts subject
+	f.puts text
+	f.close
+#	return `dayone #{dayone_cmd_options} --date="#{date} EST" new < #{fpath}`
+	return `cat #{f.path.strip} | dayone #{dayone_cmd_options} --date="#{date} EST" new `
+	rm(f)
 end
 
 # It's very likely that we're going to be iterating over multiple files, so


### PR DESCRIPTION
lj2dayone now writes entries out to a temp file, then cat's the file
into the dayone command line tool. This avoids problems with older versions of echo not being able to handle UTF-8 characters.
