### PR TITLE
Encode query parameters and add error message

### DIFF
--- a/getljxml.rb
+++ b/getljxml.rb
@@ -17,6 +17,11 @@ loginstring = 'ret=1&user=' + CGI.escape(lj_username) + '&password=' + CGI.escap
 
 puts %x(curl --cookie-jar cookies.txt --data #{loginstring.dump} #{lj_login_url.dump})
 
+# Make sure we actually logged in
+unless File.exists?('cookies.txt')
+	abort('Error: Could not log in to LiveJournal')
+end
+
 # Iterate over years, starting with firstyear and running up to the current year
 (firstyear..Time.now.year).each do |current_year|
 	# In each month of each year, send POST data that will fetch the LJ XML for that month.

--- a/getljxml.rb
+++ b/getljxml.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/ruby
+require 'cgi'
 
 # Put your username and password here
 
@@ -12,7 +13,7 @@ lj_archive_url = 'http://www.livejournal.com/export_do.bml' # XML download URL
 
 # Build login string, then log into LJ and save the cookie.
 
-loginstring = 'ret=1&user=' + lj_username + '&password=' + lj_password + '&action%3Alogin='
+loginstring = 'ret=1&user=' + CGI.escape(lj_username) + '&password=' + CGI.escape(lj_password) + '&action%3Alogin='
 
 puts %x(curl --cookie-jar cookies.txt --data #{loginstring.dump} #{lj_login_url.dump})
 


### PR DESCRIPTION
I was trying to use the script to export my journal (thank you so much for writing the tool) but ran into two problems:

- My password contained a character that needed to be escaped in the POST data when logging in, which this script wasn't doing.
- When the login failed, the script continued and downloaded a bunch of identical HTML, I assume about needing to log in.

This fixes both issues.