### PR TITLE
fix rexml parse error

### DIFF
--- a/lj2dayone.rb
+++ b/lj2dayone.rb
@@ -38,9 +38,9 @@ end
 	ljdata = REXML::Document.new(File.new(ARGV[j]))
 
 # Extract the relevant data from the ljdata xml object
-	subjects = ljdata.elements.to_a('///subject')
-	dates = ljdata.elements.to_a('///eventtime')
-	entrytexts = ljdata.elements.to_a('///event')
+	subjects = ljdata.elements.to_a('//subject')
+	dates = ljdata.elements.to_a('//eventtime')
+	entrytexts = ljdata.elements.to_a('//event')
 
 # Iterate over the array; subjects[] is used to derive the index number, but
 # that's an arbitrary choice; all three arrays should be the same length


### PR DESCRIPTION
this fixes the immediate REXML parse error. This fork looks cleaner though I haven't tested it: https://github.com/chipotle/livejournal-archive-tools